### PR TITLE
APP-7688 skip tnc step in the modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed/carbon-connect",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/components/IntegrationModal/IntegrationList.tsx
+++ b/src/components/IntegrationModal/IntegrationList.tsx
@@ -1,16 +1,10 @@
 import React, { useState } from "react";
-import {
-  emptyFunction,
-  getIntegrationName,
-  isEmpty,
-} from "@utils/helper-functions";
+import { emptyFunction, getIntegrationName } from "@utils/helper-functions";
 import SearchIcon from "@assets/svgIcons/search-icon.svg";
-import { INTEGRATIONS_LIST } from "@utils/integrationModalconstants";
 import {
   DialogHeader,
   DialogTitle,
 } from "@components/common/design-system/Dialog";
-import BackIcon from "@assets/svgIcons/back-icon.svg";
 import CrossIcon from "@assets/svgIcons/cross-icon.svg";
 import { Input } from "@components/common/design-system/Input";
 import { Button } from "@components/common/design-system/Button";
@@ -35,14 +29,12 @@ export interface IntegrationListProps {
   activeIntegrations: IntegrationAPIResponse[];
   setActiveStep?: (stepId: ActiveStep) => void;
   onCloseModal: () => void;
-  handleBack: () => void;
 }
 
 function IntegrationList({
   activeIntegrations,
   setActiveStep = emptyFunction,
   onCloseModal,
-  handleBack,
 }: IntegrationListProps) {
   const [searchText, setSearchText] = useState<string>("");
   const {
@@ -67,17 +59,6 @@ function IntegrationList({
         onCloseModal={() => onCloseModal()}
       >
         <div className="cc-flex-grow cc-flex cc-gap-3 cc-items-center">
-          <Button
-            variant="neutral-white"
-            className="cc-pr-1 cc-h-10 cc-w-auto cc-absolute sm:cc-relative cc-p-0 cc-border-none"
-            onClick={() => handleBack()}
-          >
-            <img
-              src={BackIcon}
-              alt="Lock"
-              className="cc-h-[18px] cc-w-[18px] dark:cc-invert-[1] dark:cc-hue-rotate-180"
-            />
-          </Button>
           <DialogTitle
             justifyModification={true}
             className="cc-flex-grow sm:cc-text-left"

--- a/src/components/IntegrationModal/index.tsx
+++ b/src/components/IntegrationModal/index.tsx
@@ -143,7 +143,7 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
   }, [activeIntegrations, carbonActive]);
 
   /**
-   * Skip the connect screen, since the tnc is not same as the ClearFeed's tnc
+   * Skip the connect screen, since the tnc now is same as the ClearFeed's tnc
    * and the user is already logged in
    */
   useEffect(() => {

--- a/src/components/IntegrationModal/index.tsx
+++ b/src/components/IntegrationModal/index.tsx
@@ -9,6 +9,7 @@ import { useCarbon } from "../../context/CarbonContext";
 import { ActiveStep, IntegrationName } from "../../typing/shared";
 
 import LocalFilesScreen from "../SystemFileUpload/LocalFilesScreen";
+import ConnectScreen from "@components/CarbonConnect/ConnectScreen";
 
 export interface ModalProps {}
 
@@ -153,7 +154,7 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
         setActiveStep("INTEGRATION_LIST");
       }
     }
-  }, [entryPointIntegrationObject]);
+  }, [entryPointIntegrationObject, activeStep]);
 
   const isWhiteLabeledEntryPoint =
     entryPoint && whiteLabelingData?.remove_branding;
@@ -161,7 +162,12 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
   const showActiveContent = (activeStep: ActiveStep) => {
     switch (activeStep) {
       case "CONNECT":
-        return null;
+        return (
+          <ConnectScreen
+            onPrimaryButtonClick={(step) => setActiveStep(step)}
+            setCarbonActive={setCarbonActive}
+          />
+        );
       case "INTEGRATION_LIST":
         return (
           <IntegrationList

--- a/src/components/IntegrationModal/index.tsx
+++ b/src/components/IntegrationModal/index.tsx
@@ -9,7 +9,6 @@ import { useCarbon } from "../../context/CarbonContext";
 import { ActiveStep, IntegrationName } from "../../typing/shared";
 
 import LocalFilesScreen from "../SystemFileUpload/LocalFilesScreen";
-import ConnectScreen from "@components/CarbonConnect/ConnectScreen";
 
 export interface ModalProps {}
 
@@ -47,6 +46,7 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
     setLastModifications,
     apiURL,
     dataSourceTagsFilterQuery,
+    entryPointIntegrationObject,
   } = useCarbon();
 
   const [activeIntegrations, setActiveIntegrations] = useState<
@@ -141,13 +141,19 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
     activeIntegrationsRef.current = activeIntegrations;
   }, [activeIntegrations, carbonActive]);
 
+  /**
+   * Skip the connect screen, since the tnc is not same as the ClearFeed's tnc
+   * and the user is already logged in
+   */
   useEffect(() => {
-    if (whiteLabelingData?.remove_branding && entryPoint) {
-      setActiveStep(entryPoint);
-    } else {
-      setActiveStep("CONNECT");
+    if (activeStep === "CONNECT") {
+      if (entryPointIntegrationObject?.active) {
+        setActiveStep(entryPointIntegrationObject.data_source_type);
+      } else {
+        setActiveStep("INTEGRATION_LIST");
+      }
     }
-  }, [whiteLabelingData]);
+  }, [entryPointIntegrationObject]);
 
   const isWhiteLabeledEntryPoint =
     entryPoint && whiteLabelingData?.remove_branding;
@@ -155,12 +161,7 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
   const showActiveContent = (activeStep: ActiveStep) => {
     switch (activeStep) {
       case "CONNECT":
-        return (
-          <ConnectScreen
-            onPrimaryButtonClick={(step) => setActiveStep(step)}
-            setCarbonActive={setCarbonActive}
-          />
-        );
+        return null;
       case "INTEGRATION_LIST":
         return (
           <IntegrationList

--- a/src/components/IntegrationModal/index.tsx
+++ b/src/components/IntegrationModal/index.tsx
@@ -166,11 +166,6 @@ export function IntegrationModal({ children }: { children: ReactNode }) {
         return (
           <IntegrationList
             setActiveStep={setActiveStep}
-            handleBack={
-              isWhiteLabeledEntryPoint
-                ? () => manageModalOpenState(false)
-                : () => setActiveStep("CONNECT")
-            }
             onCloseModal={() => manageModalOpenState(false)}
             activeIntegrations={activeIntegrations}
           />


### PR DESCRIPTION
Remove connect step which has tnc screen, since the carbon in now hosted by clearfeed and the tnc will be same as ClearFeed's. Instead directly take to integrations picker.


https://github.com/user-attachments/assets/5646a303-271d-4eb1-ab81-6ffb1cd9a41d

Test Cases:
1. Verified no connect screen in show in different carbon file picker modal
2. Verified above for github and google drive integrations
3. Verified back button in removed in integrations picker screen only where the back button points to connect screen

